### PR TITLE
allow controls_0 and controls_1 domname to be set through the setting…

### DIFF
--- a/archaeopteryx.js
+++ b/archaeopteryx.js
@@ -2907,7 +2907,11 @@ if (!phyloXml) {
         if (!_settings.controlsBackgroundColor) {
             _settings.controlsBackgroundColor = CONTROLS_BACKGROUND_COLOR_DEFAULT;
         }
-        if (!_settings.controls0Left) {
+        if (!_settings.controls0) {
+            _settings.controls0 = CONTROLS_0;
+            console.log('   controls0   : ' + _settings.controls0);
+        }
+		if (!_settings.controls0Left) {
             _settings.controls0Left = CONTROLS_0_LEFT_DEFAULT;
             console.log('   controls0Left   : ' + _settings.controls0Left);
         }
@@ -2916,6 +2920,10 @@ if (!phyloXml) {
         }
         if (!_settings.controls1Top) {
             _settings.controls1Top = CONTROLS_1_TOP_DEFAULT;
+        }
+        if (!_settings.controls1) {
+            _settings.controls1 = CONTROLS_1;
+            console.log('   controls1   : ' + _settings.controls1);
         }
         if (!_settings.controls1Left) {
             _settings.controls1Left = _settings.displayWidth - CONTROLS_1_WIDTH;
@@ -3650,14 +3658,14 @@ if (!phyloXml) {
             legendReset();
         }
         zoomFit();
-        var c0 = $('#' + CONTROLS_0);
+        var c0 = $('#' + _settings.controls0);
         if (c0) {
             c0.css({
                 'left': _settings.controls0Left,
                 'top': _settings.controls0Top + _offsetTop
             });
         }
-        var c1 = $('#' + CONTROLS_1);
+        var c1 = $('#' + _settings.controls1);
         if (c1) {
             c1.css({
                 'left': _settings.controls1Left,
@@ -4079,7 +4087,7 @@ if (!phyloXml) {
         }
 
 
-        var c0 = $('#' + CONTROLS_0);
+        var c0 = $('#' + _settings.controls0);
 
         if (c0) {
             c0.css({
@@ -4188,7 +4196,7 @@ if (!phyloXml) {
             }
         }
 
-        var c1 = $('#' + CONTROLS_1);
+        var c1 = $('#' + _settings.controls1);
         if (c1) {
             c1.css({
                 'position': 'absolute',


### PR DESCRIPTION
…s while leaving the default behavior intact.

hi @cmzmasek,

I've been working on a [HTMLWIDGET port](https://github.com/zachcp/archaeopteryx-js) of your excellent archaeopteryx library. Things are going well but I've run into issues when I attempt to add multiple Archaeopteryx  widgets to the same page. This is because right now, the IDs of the DOM elements for the controls are hardcoded. This PR keeps the same default names but allows for the the possibility of changing the IDs by passing them in as settings.  It shouldn't change any existing functionality but opens up extensibility a bit.

Thanks again,
zach cp

